### PR TITLE
Fix cors issue for ethprice

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -529,9 +529,11 @@ class App extends Component {
 
   }
   longPoll() {
-    axios.get("https://api.coinmarketcap.com/v2/ticker/1027/")
+    const uniswap = "https://uniswap-analytics.appspot.com/api/v1/ticker?exchangeAddress="
+    const daiExchange = "0x09cabec1ead1c0ba254b09efb3ee13841712be14"
+    axios.get(uniswap+daiExchange)
      .then((response)=>{
-       let ethprice = response.data.data.quotes.USD.price
+       const ethprice = response.data.price
        this.setState({ethprice})
      })
   }


### PR DESCRIPTION
Ethprice wouldn't load as coinmarketcap request was not possible because of CORS issues.
This PR fixes it by using Uniswap's analytics API.