### PR TITLE
Pdai approve

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -397,7 +397,7 @@ class App extends Component {
     setTimeout(this.longPoll.bind(this),150)
 
     // NOTE: Change this to mainnet again when ready for mainnet launch.
-    let mainnetweb3 = new Web3(new Web3.providers.WebsocketProvider("wss://rinkeby.infura.io/ws/v3/e0ea6e73570246bbb3d4bd042c4b5dac"));
+    let mainnetweb3 = new Web3(new Web3.providers.WebsocketProvider("wss://rinkeby.infura.io/ws/v3/f039330d8fb747e48a7ce98f51400d65"));
     let ensContract = new mainnetweb3.eth.Contract(require("./contracts/ENS.abi.js"),require("./contracts/ENS.address.js"))
     let daiContract;
     let bridgeContract;

--- a/src/components/Exchange.js
+++ b/src/components/Exchange.js
@@ -522,6 +522,8 @@ export default class Exchange extends React.Component {
         if(this.state.mainnetMetaAccount){
           //send funds using metaaccount on mainnet
 
+          // First, we approve the token we'd like to transfer to the plasma
+          // chain, then we call deposit on the bridge
           let paramsObject = {
             from: this.state.daiAddress,
             value: 0,
@@ -530,14 +532,12 @@ export default class Exchange extends React.Component {
           }
           console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
 
+          // TODO: Skip approve step if already approved.
           paramsObject.to = this.props.daiContract._address
-          paramsObject.data = this.props.bridgeContract.methods.deposit(
-            this.state.daiAddress,
-            this.state.mainnetweb3.utils.toWei(""+amount,"ether"),
-            1
+          paramsObject.data = this.props.daiContract.methods.approve(
+            this.props.bridgeContract._address,
+            "57896044618658097711785492504343953926634992332820282019728792003956564819968" // 2^255
           ).encodeABI()
-
-          console.log("TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
 
           this.state.mainnetweb3.eth.accounts.signTransaction(paramsObject, this.state.mainnetMetaAccount.privateKey).then(signed => {
             console.log("========= >>> SIGNED",signed)
@@ -545,14 +545,50 @@ export default class Exchange extends React.Component {
                 console.log("META RECEIPT",receipt)
                 if(receipt&&receipt.transactionHash&&!metaReceiptTracker[receipt.transactionHash]){
                   metaReceiptTracker[receipt.transactionHash] = true
-                  cb(receipt)
-                }
-              }).on('error', (err)=>{
-                console.log("EEEERRRRRRRROOOOORRRRR ======== >>>>>",err)
-                this.props.changeAlert({type: 'danger',message: err.toString()});
-              }).then(console.log)
-          });
+                  // NOTE: For the approve we do not already call the call back
+                  // of this function. The outer function depends on cb to
+                  // contain a receipt of the bridge. Hence, we call back
+                  // after we successfully sent the second transaction (bridge.deposit).
+                  // cb(receipt)
+                  paramsObject = {
+                    from: this.state.daiAddress,
+                    value: 0,
+                    // TODO: I guess this should be calculated by web3's gas
+                    // estimate?
+                    gas: 200000,
+                    gasPrice: Math.round(gwei * 1000000000)
+                  }
+                  console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
 
+                  paramsObject.to = this.props.bridgeContract._address
+                  paramsObject.data = this.props.bridgeContract.methods.deposit(
+                    this.state.daiAddress,
+                    this.state.mainnetweb3.utils.toWei(""+amount,"ether"),
+                    0
+                  ).encodeABI()
+
+                  console.log("TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
+
+                  this.state.mainnetweb3.eth.accounts.signTransaction(paramsObject, this.state.mainnetMetaAccount.privateKey).then(signed => {
+                    console.log("========= >>> SIGNED",signed)
+                      this.state.mainnetweb3.eth.sendSignedTransaction(signed.rawTransaction).on('receipt', (receipt)=>{
+                        console.log("META RECEIPT deposit",receipt)
+                        if(receipt&&receipt.transactionHash&&!metaReceiptTracker[receipt.transactionHash]){
+                          metaReceiptTracker[receipt.transactionHash] = true
+                          console.log(cb)
+                          cb(receipt)
+                        }
+                      }).on('error', (err)=>{
+                        console.log("EEEERRRRRRRROOOOORRRRR ======== >>>>>",err)
+                        this.props.changeAlert({type: 'danger',message: err.toString()});
+                      }).then(console.log)
+                  });
+                        }
+                      }).on('error', (err)=>{
+                        console.log("EEEERRRRRRRROOOOORRRRR ======== >>>>>",err)
+                        this.props.changeAlert({type: 'danger',message: err.toString()});
+                      }).then(console.log)
+                  });
         }else{
           //send funds using metamask (or other injected web3 ... should be checked and on mainnet)
           console.log("Depositing to ",toDaiBridgeAccount)

--- a/src/components/Exchange.js
+++ b/src/components/Exchange.js
@@ -17,6 +17,7 @@ import wyrelogo from '../wyre.png';
 import InputRange from 'react-input-range';
 import 'react-input-range/lib/css/index.css';
 
+const BN = Web3.utils.BN
 const GASBOOSTPRICE = 0.25
 
 const logoStyle = {
@@ -506,6 +507,8 @@ export default class Exchange extends React.Component {
   }
   // TODO: Make this whole approve situation optional and only when LeapNetwork is used
   async transferDai(destination,amount,message,cb) {
+    // Inspired by: https://github.com/leapdao/bridge-ui/blob/427f72944c31a62f687f3b53a35c4115765efada/src/stores/token.ts#L281
+    const approveAmount = new BN("2").pow(new BN("255"));
     let response
     try {
       response = await axios.get("https://ethgasstation.info/json/ethgasAPI.json", { crossdomain: true })
@@ -540,8 +543,7 @@ export default class Exchange extends React.Component {
         paramsObject.to = this.props.daiContract._address
         paramsObject.data = this.props.daiContract.methods.approve(
           this.props.bridgeContract._address,
-          // TODO: Change this to a calculation
-          "57896044618658097711785492504343953926634992332820282019728792003956564819968" // 2^255
+          approveAmount
         ).encodeABI()
 
         const signedApprove = await this.state.mainnetweb3.eth.accounts.signTransaction(paramsObject, this.state.mainnetMetaAccount.privateKey)
@@ -612,12 +614,10 @@ export default class Exchange extends React.Component {
             })
           })
         }
-        console.log("daiContract", this.props.daiContract)
         const approveReceipt = await tx(
           daiContract.methods.approve(
             bridgeContract._address,
-            // TODO: Change this to a calculation
-            "57896044618658097711785492504343953926634992332820282019728792003956564819968" // 2^255
+            approveAmount
           ),
           ///TODO LET ME PASS IN A CERTAIN AMOUNT OF GAS INSTEAD OF LEANING BACK ON THE <GAS> COMPONENT!!!!!
           150000,


### PR DESCRIPTION
Note that this branch is based on #10 aka pdai-transaction history. It will get easier to review when we merge #10.

Fixes #6. Calls approve if allowance is not setup for account. Works for both Metmask and non-metamask browser.

I rewrote the whole `transferDai` function to async/await as it would get really messy without.