### PR TITLE
feat: support mainnet and testnet sundai without hardcode

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1834,6 +1834,7 @@ render() {
                     mainnetweb3={this.state.mainnetweb3}
                     xdaiweb3={this.state.xdaiweb3}
                     daiContract={this.state.daiContract}
+                    pdaiContract={this.state.pdaiContract}
                     ensContract={this.state.ensContract}
                     bridgeContract={this.state.bridgeContract}
                     isVendor={this.state.isVendor}

--- a/src/App.js
+++ b/src/App.js
@@ -71,6 +71,10 @@ let LOADERIMAGE = burnerlogo
 let HARDCODEVIEW// = "loader"// = "receipt"
 let FAILCOUNT = 0
 
+// Mainnet DAI by default
+let DAI_TOKEN_ADDR = '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359';
+let P_DAI_TOKEN_ADDR = '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359';
+
 let mainStyle = {
   width:"100%",
   height:"100%",
@@ -90,6 +94,11 @@ let titleImage = (
 if (window.location.hostname.indexOf("localhost") >= 0 || window.location.hostname.indexOf("10.0.0.107") >= 0) {
   XDAI_PROVIDER = "wss://testnet-node1.leapdao.org:1443";
   WEB3_PROVIDER = "https://rinkeby.infura.io/v3/f039330d8fb747e48a7ce98f51400d65"
+  
+  // LEAP token instead of DAI
+  DAI_TOKEN_ADDR = '0xD2D0F8a6ADfF16C2098101087f9548465EC96C98';
+  P_DAI_TOKEN_ADDR = '0xD2D0F8a6ADfF16C2098101087f9548465EC96C98';
+
   CLAIM_RELAY = false;
   ERC20NAME = false;
   ERC20TOKEN = false;
@@ -120,14 +129,35 @@ else if (window.location.hostname.indexOf("xdai") >= 0) {
 else if (window.location.hostname.indexOf("burner.leapdao.org") >= 0) {
   XDAI_PROVIDER = "wss://testnet-node1.leapdao.org:1443";
   WEB3_PROVIDER = "wss://rinkeby.infura.io/ws/v3/f039330d8fb747e48a7ce98f51400d65";
+  // LEAP token instead of DAI
+  DAI_TOKEN_ADDR = '0xD2D0F8a6ADfF16C2098101087f9548465EC96C98';
+  P_DAI_TOKEN_ADDR = '0xD2D0F8a6ADfF16C2098101087f9548465EC96C98';  
   CLAIM_RELAY = false;
   ERC20NAME = false;
   ERC20TOKEN = false;
   ERC20IMAGE = false;
 }
 else if (window.location.hostname.indexOf("sundai.io") >= 0) {
+  XDAI_PROVIDER = "wss://mainnet-node1.leapdao.org:1443";
+  WEB3_PROVIDER = "wss://mainnet.infura.io/ws/v3/f039330d8fb747e48a7ce98f51400d65";
+
+  // mainnet sunDAI for Plasma DAI
+  P_DAI_TOKEN_ADDR = '0x3cC0DF021dD36eb378976142Dc1dE3F5726bFc48';
+  
+  CLAIM_RELAY = false;
+  ERC20NAME = false;
+  ERC20TOKEN = false;
+  ERC20IMAGE = false;
+}
+else if (window.location.hostname.indexOf("sundai.local") >= 0) {
   XDAI_PROVIDER = "wss://testnet-node1.leapdao.org:1443";
   WEB3_PROVIDER = "wss://rinkeby.infura.io/ws/v3/f039330d8fb747e48a7ce98f51400d65";
+
+  // testnet LEAP for DAI
+  // testnet sunDAI for Plasma DAI
+  DAI_TOKEN_ADDR = '0xD2D0F8a6ADfF16C2098101087f9548465EC96C98';
+  P_DAI_TOKEN_ADDR = '0xeFb369E2c694Bc0ba31945e0D3ac91Ab8E943be3';
+  
   CLAIM_RELAY = false;
   ERC20NAME = false;
   ERC20TOKEN = false;
@@ -410,7 +440,7 @@ class App extends Component {
     let daiContract;
     let bridgeContract;
     try{
-      daiContract = new mainnetweb3.eth.Contract(require("./contracts/StableCoin.abi.js"),"0xD2D0F8a6ADfF16C2098101087f9548465EC96C98")
+      daiContract = new mainnetweb3.eth.Contract(require("./contracts/StableCoin.abi.js"),DAI_TOKEN_ADDR)
       bridgeContract = new mainnetweb3.eth.Contract(require("./contracts/Bridge.abi.js"), require("./contracts/Bridge.address.js"))
     }catch(e){
       console.log("ERROR LOADING DAI Stablecoin Contract",e)
@@ -1923,7 +1953,7 @@ render() {
           if (state.xdaiweb3) {
             let pdaiContract;
             try{
-              pdaiContract = new state.xdaiweb3.eth.Contract(require("./contracts/StableCoin.abi.js"),"0xD2D0F8a6ADfF16C2098101087f9548465EC96C98")
+              pdaiContract = new state.xdaiweb3.eth.Contract(require("./contracts/StableCoin.abi.js"),P_DAI_TOKEN_ADDR)
             }catch(e){
               console.log("ERROR LOADING DAI Stablecoin Contract",e)
             }

--- a/src/components/Exchange.js
+++ b/src/components/Exchange.js
@@ -551,6 +551,8 @@ export default class Exchange extends React.Component {
       response.data.average=response.data.average + (response.data.average*GASBOOSTPRICE)
       let gwei = Math.round(response.data.average*100)/1000
 
+      const color = await this.state.xdaiweb3.getColor(this.props.pdaiContract._address);
+      
       if(this.state.mainnetMetaAccount){
         //send funds using metaaccount on mainnet
         const amountWei = this.state.mainnetweb3.utils.toWei(""+amount,"ether")
@@ -617,7 +619,7 @@ export default class Exchange extends React.Component {
         paramsObject.data = this.props.bridgeContract.methods.deposit(
           this.state.daiAddress,
           amountWei,
-          0
+          color,
         ).encodeABI()
         console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
 
@@ -688,7 +690,7 @@ export default class Exchange extends React.Component {
           bridgeContract.methods.deposit(
             this.state.daiAddress,
             amountWei,
-            0
+            color,
           ),
           ///TODO LET ME PASS IN A CERTAIN AMOUNT OF GAS INSTEAD OF LEANING BACK ON THE <GAS> COMPONENT!!!!!
           150000,


### PR DESCRIPTION
By domain.

`sundai.io` — mainnet DAI + mainnet sunDAI
`sundai.local` — testnet LEAP + testnet sunDAI
`burner.leapdao.org` and `localhost` — testnet LEAP
otherwise — mainnet DAI