### PR TITLE
fix: Out of Gas when depositing with metamask

### DIFF
--- a/src/components/Exchange.js
+++ b/src/components/Exchange.js
@@ -790,7 +790,7 @@ export default class Exchange extends React.Component {
             color,
           ),
           ///TODO LET ME PASS IN A CERTAIN AMOUNT OF GAS INSTEAD OF LEANING BACK ON THE <GAS> COMPONENT!!!!!
-          150000,
+          200000,
           0,
           0
         )


### PR DESCRIPTION
meta accounts use different gasLimit of 200000, which works fine.
Setting the same limit for metamask deposits.

Actual gas used is ~153000