### PR TITLE
feat: allow to exit sunDAI via exit market maker

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -78,6 +78,8 @@ let P_DAI_TOKEN_ADDR = '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359';
 // Mainnet Leap Bridge(ExitHandler)
 let BRIDGE_ADDR = '0x0036192587fD788B75829fbF79BE7F06E4F23B21';
 
+let MARKET_MAKER;
+
 let leapNetwork;
 
 let mainStyle = {
@@ -106,6 +108,8 @@ if (window.location.hostname.indexOf("localhost") >= 0 || window.location.hostna
 
   // Testnet Leap Bridge(ExitHandler)
   BRIDGE_ADDR = '0x2c2a3b359edbCFE3c3Ac0cD9f9F1349A96C02530';
+
+  MARKET_MAKER = 'https://2nuxsb25he.execute-api.eu-west-1.amazonaws.com/testnet/';
 
   CLAIM_RELAY = false;
   ERC20NAME = false;
@@ -144,6 +148,8 @@ else if (window.location.hostname.indexOf("burner.leapdao.org") >= 0) {
   // Testnet Leap Bridge(ExitHandler)
   BRIDGE_ADDR = '0x2c2a3b359edbCFE3c3Ac0cD9f9F1349A96C02530';
 
+  MARKET_MAKER = 'https://2nuxsb25he.execute-api.eu-west-1.amazonaws.com/testnet/';
+
   CLAIM_RELAY = false;
   ERC20NAME = false;
   ERC20TOKEN = false;
@@ -157,6 +163,8 @@ else if (window.location.hostname.indexOf("sundai.io") >= 0) {
   // mainnet sunDAI for Plasma DAI
   P_DAI_TOKEN_ADDR = '0x3cC0DF021dD36eb378976142Dc1dE3F5726bFc48';
 
+  MARKET_MAKER = '';
+  
   CLAIM_RELAY = false;
   ERC20NAME = false;
   ERC20TOKEN = false;
@@ -175,6 +183,8 @@ else if (window.location.hostname.indexOf("sundai.local") >= 0 ||
 
   // Testnet Leap Bridge(ExitHandler)
   BRIDGE_ADDR = '0x2c2a3b359edbCFE3c3Ac0cD9f9F1349A96C02530';
+
+  MARKET_MAKER = 'https://2nuxsb25he.execute-api.eu-west-1.amazonaws.com/testnet/';
 
   CLAIM_RELAY = false;
   ERC20NAME = false;
@@ -1876,6 +1886,8 @@ render() {
                     balance={balance}
                     goBack={this.goBack.bind(this)}
                     dollarDisplay={dollarDisplay}
+                    tokenSendV2={tokenSendV2.bind(this)}
+                    marketMaker={MARKET_MAKER}
                   />
                 </div>
                 <Bottom

--- a/src/App.js
+++ b/src/App.js
@@ -109,7 +109,7 @@ if (window.location.hostname.indexOf("localhost") >= 0 || window.location.hostna
   // Testnet Leap Bridge(ExitHandler)
   BRIDGE_ADDR = '0x2c2a3b359edbCFE3c3Ac0cD9f9F1349A96C02530';
 
-  MARKET_MAKER = 'https://2nuxsb25he.execute-api.eu-west-1.amazonaws.com/testnet/';
+  MARKET_MAKER = 'https://2nuxsb25he.execute-api.eu-west-1.amazonaws.com/testnet';
 
   CLAIM_RELAY = false;
   ERC20NAME = false;
@@ -148,7 +148,7 @@ else if (window.location.hostname.indexOf("burner.leapdao.org") >= 0) {
   // Testnet Leap Bridge(ExitHandler)
   BRIDGE_ADDR = '0x2c2a3b359edbCFE3c3Ac0cD9f9F1349A96C02530';
 
-  MARKET_MAKER = 'https://2nuxsb25he.execute-api.eu-west-1.amazonaws.com/testnet/';
+  MARKET_MAKER = 'https://2nuxsb25he.execute-api.eu-west-1.amazonaws.com/testnet';
 
   CLAIM_RELAY = false;
   ERC20NAME = false;
@@ -163,7 +163,7 @@ else if (window.location.hostname.indexOf("sundai.io") >= 0) {
   // mainnet sunDAI for Plasma DAI
   P_DAI_TOKEN_ADDR = '0x3cC0DF021dD36eb378976142Dc1dE3F5726bFc48';
 
-  MARKET_MAKER = '';
+  MARKET_MAKER = 'https://k238oyefqc.execute-api.eu-west-1.amazonaws.com/mainnet';
   
   CLAIM_RELAY = false;
   ERC20NAME = false;
@@ -184,7 +184,7 @@ else if (window.location.hostname.indexOf("sundai.local") >= 0 ||
   // Testnet Leap Bridge(ExitHandler)
   BRIDGE_ADDR = '0x2c2a3b359edbCFE3c3Ac0cD9f9F1349A96C02530';
 
-  MARKET_MAKER = 'https://2nuxsb25he.execute-api.eu-west-1.amazonaws.com/testnet/';
+  MARKET_MAKER = 'https://2nuxsb25he.execute-api.eu-west-1.amazonaws.com/testnet';
 
   CLAIM_RELAY = false;
   ERC20NAME = false;

--- a/src/components/Exchange.js
+++ b/src/components/Exchange.js
@@ -210,7 +210,7 @@ export default class Exchange extends React.Component {
     })
     .then(response => response.json())
     .then(rsp => {
-      if (rsp.length === 0) {
+      if (rsp.length === 0 || !rsp.reduce) {
         this.setState({
           pendingMsg: null
         });

--- a/src/components/Exchange.js
+++ b/src/components/Exchange.js
@@ -19,7 +19,7 @@ import 'react-input-range/lib/css/index.css';
 
 import { Exit } from 'leap-core';
 import { fromRpcSig } from 'ethereumjs-util';
-import { bi, add, divide } from 'jsbi-utils';
+import { bi, add, divide, lessThan } from 'jsbi-utils';
 
 const BN = Web3.utils.BN
 const GASBOOSTPRICE = 0.25
@@ -125,6 +125,30 @@ export default class Exchange extends React.Component {
     this.getWrappedDaiBalance();
   }
 
+  delay(time) {
+    return new Promise(resolve => setTimeout(resolve, time));
+  }
+
+  getTransactionReceiptMined(txHash) {
+    const transactionReceiptRetry = () => this.state.mainnetweb3.eth.getTransactionReceipt(txHash)
+        .then(receipt => receipt != null
+            ? receipt
+            : this.delay(2000).then(transactionReceiptRetry));
+    return transactionReceiptRetry();
+  }
+
+  async getGasPrice() {
+    const rsp = await axios.get("https://ethgasstation.info/json/ethgasAPI.json", { crossdomain: true })
+      .catch((err)=>{
+        console.log("Error getting gas price", err)
+      });
+
+    if(rsp && rsp.data.average > 0 && rsp.data.average < 200) {
+      rsp.data.average = rsp.data.average + (rsp.data.average * GASBOOSTPRICE);
+      return Math.round(rsp.data.average * 100) / 1000;
+    }
+  }
+
   async getWrappedDaiBalance() {
     // not a sundai, return immediatelly
     if (this.state.notSundai) return true;
@@ -180,7 +204,7 @@ export default class Exchange extends React.Component {
     xdaiweb3.getColor(tokenAddr)
     .then(color => {
       return fetch(
-      `https://2nuxsb25he.execute-api.eu-west-1.amazonaws.com/testnet/exits/${account}/${color}`,
+        `${this.props.marketMaker}/exits/${account}/${color}`,
       { method: "GET", mode: "cors" }
       );
     })
@@ -201,6 +225,132 @@ export default class Exchange extends React.Component {
     });
   };
 
+  async rootNetworkSend(to, tx, gasLimit = 100000) {
+    if (this.state.mainnetMetaAccount) {
+      const gwei = await this.getGasPrice();
+
+      let paramsObject = {
+        from: this.state.daiAddress,
+        value: 0,
+        gas: gasLimit,
+        gasPrice: Math.round(gwei * 1000000000)
+      }
+
+      paramsObject.to = to;
+      paramsObject.data = tx.encodeABI();
+
+      const signed = await this.state.mainnetweb3.eth.accounts
+        .signTransaction(paramsObject, this.state.mainnetMetaAccount.privateKey);
+    
+      console.log("========= >>> SIGNED",signed)
+      return this.state.mainnetweb3.eth.sendSignedTransaction(signed.rawTransaction);
+    } else {
+      return this.props.pTx(tx, 150000, 0, 0);
+    }
+  }
+
+  async directSell(amount, color) {
+    // do not allow to exit more than daiBalance from SunDai
+    if (lessThan(bi(this.state.exitableSunDaiBalance), amount)) {
+      amount = bi(this.state.exitableSunDaiBalance);
+    }
+
+    console.log('Exitable amount', amount.toString());
+
+    let rsp = await axios.get(`${this.props.marketMaker}/deals`, { crossdomain: true });
+
+    const market = rsp.data.deals.find(deal => deal.color === color);
+    if (!market || lessThan(bi(market.balance), amount)) {
+      this.props.changeAlert({
+        type: 'warning',
+        message: 'Not enough liquidity on the market'
+      });
+      return;
+    }
+
+    const mmAddress = rsp.data.address;
+    console.log(mmAddress, rsp);
+      
+    this.setState({
+      daiToXdaiMode:"withdrawing",
+      amount:"",
+      loaderBarColor:"#4ab3f5",
+      loaderBarStatusText:"Transferring to market maker...",
+    })
+
+    let receipt = await this.props.tokenSendV2(
+      this.state.daiAddress,
+      mmAddress,
+      amount,
+      color,
+      this.state.xdaiweb3,
+      this.props.web3,
+      this.state.mainnetMetaAccount && this.state.mainnetMetaAccount.privateKey
+    )
+
+    console.log('Transfer to market maker:', receipt);
+
+    this.setState({
+      daiToXdaiMode:"withdrawing",
+      amount:"",
+      loaderBarColor:"#4ab3f5",
+      loaderBarStatusText:"Posting sell request...",
+    })
+
+    rsp = await axios.post(`${this.props.marketMaker}/directSell`, {
+      txHash: receipt.hash,
+    }, { crossdomain: true }).catch(e => {
+      console.error(e);
+      this.props.changeAlert({
+        type: 'warning',
+        message: 'Failed to sell'
+      });
+    });
+
+    console.log('Payout tx', rsp.data);
+
+    this.setState({
+      daiToXdaiMode:"withdrawing",
+      amount:"",
+      loaderBarColor:"#4ab3f5",
+      loaderBarStatusText:"Waiting for payout tx to mine...",
+    })
+    receipt = await this.getTransactionReceiptMined(rsp.data);
+
+    console.log('got receipt', receipt);
+
+    if (!receipt.status) {
+      console.log('Payout failed');
+      return;
+    };
+
+    this.setState({
+      daiToXdaiMode:"withdrawing",
+      amount:"",
+      loaderBarColor:"#4ab3f5",
+      loaderBarStatusText:"Unwrapping sunDAI for DAI...",
+    })
+
+    const web3 = this.state.mainnetMetaAccount
+      ? this.props.mainnetweb3
+      : this.props.web3;
+
+    const sunDai = new web3.eth.Contract(
+      require("../contracts/SunDai.abi.js"),
+      this.props.pdaiContract._address,
+    )
+
+    receipt = await this.rootNetworkSend(sunDai._address, sunDai.methods.burnSender());
+
+    console.log(receipt);
+
+    this.setState({
+      daiToXdaiMode:"",
+      amount:"",
+      loaderBarColor:"#4ab3f5",
+      loaderBarStatusText:"",
+    })    
+  }
 
   updateState = (key, value) => {
     this.setState({ [key]: value },()=>{
@@ -1545,9 +1695,11 @@ export default class Exchange extends React.Component {
               </Scaler>
             </div>
             <div className="col-3 p-1">
-              <button className="btn btn-large w-100"  disabled={buttonsDisabled} style={this.props.buttonStyle.primary} onClick={()=>{
+              <button className="btn btn-large w-100"  disabled={buttonsDisabled} style={this.props.buttonStyle.primary} onClick={async ()=>{
                 console.log("AMOUNT:",this.state.amount,"DAI BALANCE:",this.props.daiBalance)
                 console.log("Withdrawing to ",toDaiBridgeAccount)
+
+                let exitableAmount = this.state.amount;
 
                 if(this.state.xdaiMetaAccount){
                   //send funds using metaaccount on xdai
@@ -1567,30 +1719,35 @@ export default class Exchange extends React.Component {
                   };
 
                   // TODO: get real decimals
-                  const amount = bi(this.state.amount * 10 ** 18);
+                  const amount = bi(exitableAmount * 10 ** 18);
                   const tokenAddr = this.props.pdaiContract._address;
-                  this.state.xdaiweb3.getColor(tokenAddr)
-                    .then(color =>
-                      Exit.fastSellAmount(
-                        this.state.daiAddress, amount, color,
-                        this.state.xdaiweb3, this.props.web3,
-                        'https://2nuxsb25he.execute-api.eu-west-1.amazonaws.com/testnet/sellExit',
-                        signer,
-                      )
-                    ).then(rsp => {
-                      console.log(rsp);
-                      this.updatePendingExits(this.state.daiAddress, this.state.xdaiweb3);
-                      this.setState({ amount: "", daiToXdaiMode: false });
-                    }).catch(err => {
-                      console.log(err);
-                    });
+                  const color = await this.state.xdaiweb3.getColor(tokenAddr);
+
+                  // special handler for sunDai
+                  if (!this.state.notSundai) {
+                    this.directSell(amount, color);
+                    return;
+                  }
+
+                  Exit.fastSellAmount(
+                    this.state.daiAddress, amount, color,
+                    this.state.xdaiweb3, this.props.web3,
+                    `${this.props.marketMaker}/sellExit`,
+                    signer,
+                  ).then(rsp => {
+                    console.log(rsp);
+                    this.updatePendingExits(this.state.daiAddress, this.state.xdaiweb3);
+                    this.setState({ amount: "", daiToXdaiMode: false });
+                  }).catch(err => {
+                    console.log(err);
+                  });
 
                 }else{
 
                   //BECAUSE THIS COULD BE ON A TOKEN, THE SEND FUNCTION IS SENDING TOKENS TO THE BRIDGE HAHAHAHA LETs FIX THAT
                   if(this.props.ERC20TOKEN){
-                    console.log("native sending ",this.state.amount," to ",toDaiBridgeAccount)
-                    this.props.nativeSend(toDaiBridgeAccount, this.state.amount, 120000, (err, result) => {
+                    console.log("native sending ",exitableAmount," to ",toDaiBridgeAccount)
+                    this.props.nativeSend(toDaiBridgeAccount, exitableAmount, 120000, (err, result) => {
                       console.log("RESUTL!!!!",result)
                       if(result && result.transactionHash){
                         this.setState({
@@ -1605,23 +1762,28 @@ export default class Exchange extends React.Component {
                     })
                   }else{
                     // TODO: get real decimals
-                    const amount = bi(this.state.amount * 10 ** 18);
+                    let amount = bi(exitableAmount * 10 ** 18);
                     const tokenAddr = this.props.pdaiContract._address;
 
-                    this.state.xdaiweb3.getColor(tokenAddr)
-                      .then(color =>
-                        Exit.fastSellAmount(
-                          this.state.daiAddress, amount, color,
-                          this.state.xdaiweb3, this.props.web3,
-                          'https://2nuxsb25he.execute-api.eu-west-1.amazonaws.com/testnet/sellExit'
-                        )
-                      ).then(rsp => {
-                        console.log(rsp);
-                        this.updatePendingExits(this.state.daiAddress, this.state.xdaiweb3);
-                        this.setState({ amount: "", daiToXdaiMode: false });
-                      }).catch(err => {
-                        console.log(err);
-                      });
+                    const color = await this.state.xdaiweb3.getColor(tokenAddr);
+
+                    // special handler for sunDai
+                    if (!this.state.notSundai) {
+                      this.directSell(amount, color);
+                      return;
+                    }
+                    
+                    Exit.fastSellAmount(
+                      this.state.daiAddress, amount, color,
+                      this.state.xdaiweb3, this.props.web3,
+                      `${this.props.marketMaker}/sellExit`
+                    ).then(rsp => {
+                      console.log(rsp);
+                      this.updatePendingExits(this.state.daiAddress, this.state.xdaiweb3);
+                      this.setState({ amount: "", daiToXdaiMode: false });
+                    }).catch(err => {
+                      console.log(err);
+                    });
                   }
                 }
               }}>

--- a/src/contracts/SunDai.abi.js
+++ b/src/contracts/SunDai.abi.js
@@ -1,0 +1,238 @@
+module.exports = [
+  {
+    constant: true,
+    inputs: [],
+    name: "name",
+    outputs: [{ name: "", type: "bytes32" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "decimals",
+    outputs: [{ name: "", type: "uint8" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "bridgeAddr",
+    outputs: [{ name: "", type: "address" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "symbol",
+    outputs: [{ name: "", type: "bytes32" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [],
+    name: "renounceMinter",
+    outputs: [],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [{ name: "account", type: "address" }],
+    name: "isMinter",
+    outputs: [{ name: "", type: "bool" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [{ name: "", type: "address" }],
+    name: "daiBalance",
+    outputs: [{ name: "", type: "uint256" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "dai",
+    outputs: [{ name: "", type: "address" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    inputs: [
+      { name: "_daiAddr", type: "address" },
+      { name: "_bridgeAddr", type: "address" },
+      { name: "_name", type: "bytes32" },
+      { name: "_symbol", type: "bytes32" }
+    ],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "constructor"
+  },
+  {
+    anonymous: false,
+    inputs: [{ indexed: true, name: "account", type: "address" }],
+    name: "MinterAdded",
+    type: "event"
+  },
+  {
+    anonymous: false,
+    inputs: [{ indexed: true, name: "account", type: "address" }],
+    name: "MinterRemoved",
+    type: "event"
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, name: "from", type: "address" },
+      { indexed: true, name: "to", type: "address" },
+      { indexed: false, name: "value", type: "uint256" }
+    ],
+    name: "Transfer",
+    type: "event"
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, name: "owner", type: "address" },
+      { indexed: true, name: "spender", type: "address" },
+      { indexed: false, name: "value", type: "uint256" }
+    ],
+    name: "Approval",
+    type: "event"
+  },
+  {
+    constant: false,
+    inputs: [
+      { name: "from", type: "address" },
+      { name: "to", type: "address" },
+      { name: "value", type: "uint256" }
+    ],
+    name: "transferFrom",
+    outputs: [{ name: "", type: "bool" }],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [],
+    name: "burnSender",
+    outputs: [],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [{ name: "_newMinter", type: "address" }],
+    name: "addMinter",
+    outputs: [],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "value", type: "uint256" }
+    ],
+    name: "mint",
+    outputs: [{ name: "", type: "bool" }],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "totalSupply",
+    outputs: [{ name: "", type: "uint256" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [{ name: "owner", type: "address" }],
+    name: "balanceOf",
+    outputs: [{ name: "", type: "uint256" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" }
+    ],
+    name: "allowance",
+    outputs: [{ name: "", type: "uint256" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "value", type: "uint256" }
+    ],
+    name: "transfer",
+    outputs: [{ name: "", type: "bool" }],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "value", type: "uint256" }
+    ],
+    name: "approve",
+    outputs: [{ name: "", type: "bool" }],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "addedValue", type: "uint256" }
+    ],
+    name: "increaseAllowance",
+    outputs: [{ name: "", type: "bool" }],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "subtractedValue", type: "uint256" }
+    ],
+    name: "decreaseAllowance",
+    outputs: [{ name: "", type: "bool" }],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  }
+];


### PR DESCRIPTION
Includes #61 which can be reviewed separately

There is a special endpoint allowing to exit plasma using exit market maker custody — used for sunDai.
For other tokens (e.g. LEAP on burner.leapdao.org) fast exit will happen via FastExitHandler

Flow:

- user queries /deals endpoint to see if there is a market and liquidity for a given token
- if user decides to proceed, he transfers his tokens to market maker address on plasma. Address is provided by /deals endpoint as well
- user does POST /directSell with { txHash } payload. Market maker should check given tx and payout the user on the root network. Endpoint returns txHash of the payout
- user waits for payout tx to mine and executes burnSender to get his DAI on the root network

Backend part: https://github.com/leapdao/exit-market-maker/pull/10

Resolves #41 