### PR TITLE
Use erc721-balance for faster queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8040,6 +8040,378 @@
       "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA==",
       "dev": true
     },
+    "erc721-balance": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/erc721-balance/-/erc721-balance-0.0.1.tgz",
+      "integrity": "sha512-l4YXTTn4p5DqRw51CYbPIIWH0w3sRgvqXRIyy+gKVbAh0tzNxnZ9SuCPaIF5XXQNxkRy9YhmGvnS8Ynd12OImw==",
+      "requires": {
+        "node-fetch": "^2.3.0",
+        "web3": "^1.0.0-beta.52",
+        "web3-utils": "^1.0.0-beta.52"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.3.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+          "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "ethers": {
+          "version": "4.0.27",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.27.tgz",
+          "integrity": "sha512-+DXZLP/tyFnXWxqr2fXLT67KlGUfLuvDkHSOtSC9TUVG9OIj6yrG5JPeXRMYo15xkOYwnjgdMKrXp5V94rtjJA==",
+          "requires": {
+            "@types/node": "^10.3.2",
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.3.3",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "setimmediate": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+              "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+            }
+          }
+        },
+        "eventemitter3": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+          "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+        },
+        "swarm-js": {
+          "version": "0.1.39",
+          "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz",
+          "integrity": "sha512-QLMqL2rzF6n5s50BptyD6Oi0R1aWlJC5Y17SRIVXRj6OR1DRIPM7nepvrxxkjA1zNzFz6mUOMjfeqeDaWB7OOg==",
+          "requires": {
+            "bluebird": "^3.5.0",
+            "buffer": "^5.0.5",
+            "decompress": "^4.0.0",
+            "eth-lib": "^0.1.26",
+            "fs-extra": "^4.0.2",
+            "got": "^7.1.0",
+            "mime-types": "^2.1.16",
+            "mkdirp-promise": "^5.0.1",
+            "mock-fs": "^4.1.0",
+            "setimmediate": "^1.0.5",
+            "tar": "^4.0.2",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "tar": {
+          "version": "4.4.8",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3": {
+          "version": "1.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.52.tgz",
+          "integrity": "sha512-IWBV1gS7sElHqD2mkwjdyeEmY4YhWn7C+b+pdOWgDJ6j70ux2bqVMfsP0saZ9nWeF1TWMvUnrFsyZ7C4/VnhTA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/node": "^10.12.18",
+            "web3-bzz": "1.0.0-beta.52",
+            "web3-core": "1.0.0-beta.52",
+            "web3-core-helpers": "1.0.0-beta.52",
+            "web3-core-method": "1.0.0-beta.52",
+            "web3-eth": "1.0.0-beta.52",
+            "web3-eth-personal": "1.0.0-beta.52",
+            "web3-net": "1.0.0-beta.52",
+            "web3-providers": "1.0.0-beta.52",
+            "web3-shh": "1.0.0-beta.52",
+            "web3-utils": "1.0.0-beta.52"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.52.tgz",
+          "integrity": "sha512-yva0KW0cIEdFyHaGMHuMGjl4jea/esNBVwfFsejNRJy2W2jSMjnji+AFXnkcq8MhOAyNtQD4WzNdad9F51PaZg==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/node": "^10.12.18",
+            "lodash": "^4.17.11",
+            "swarm-js": "^0.1.39"
+          }
+        },
+        "web3-core": {
+          "version": "1.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.52.tgz",
+          "integrity": "sha512-UKHNBIj5b4M40DrGJRQKgWTtbqZCCZck38oQgBbtLAUUQmvlZybLf8jGWUfMamyhJg/eBqT/t1l7OcAn5i9zrA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^10.12.18",
+            "lodash": "^4.17.11",
+            "web3-utils": "1.0.0-beta.52"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.52.tgz",
+          "integrity": "sha512-VJCJMEplvrU7jCgn0MCuLLa+XWkQVttQpShM5i0XkcKs2gmisMtoLO3lATx2b32ruu29EriBYkkAVzc0/nxppg==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "lodash": "^4.17.11",
+            "web3-eth-iban": "1.0.0-beta.52",
+            "web3-utils": "1.0.0-beta.52"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.52.tgz",
+          "integrity": "sha512-lLbDsV2pxxrUDIWvRI/u6MsvG8mKGfCYOifXqb+yqAruhoNs/Gahoa/1UTjsn0qhVQafsffFRXaEhi6BQDQOYA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "eventemitter3": "3.1.0",
+            "lodash": "^4.17.11"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.52.tgz",
+          "integrity": "sha512-ZE6VsTVZ9PHV3FOJHnXOxUr4RuwXUpqC+RxCESb/UXvwHNnPbKNPpQjcoc5shaFrtOVtY14bIl35qTxVHSeGWg==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "eventemitter3": "^3.1.0",
+            "lodash": "^4.17.11"
+          }
+        },
+        "web3-eth": {
+          "version": "1.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.52.tgz",
+          "integrity": "sha512-mpuIFSIke/ZVdWfEzq0QRJAxcDh50BJflsdUMbNaxf5prP7Sz8FZJz/fHiu4H4cEM6aW8Bi0Hsoqad4+caX6Uw==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "ethereumjs-tx": "^1.3.7",
+            "rxjs": "^6.4.0",
+            "web3-core": "1.0.0-beta.52",
+            "web3-core-helpers": "1.0.0-beta.52",
+            "web3-core-method": "1.0.0-beta.52",
+            "web3-core-subscriptions": "1.0.0-beta.52",
+            "web3-eth-abi": "1.0.0-beta.52",
+            "web3-eth-accounts": "1.0.0-beta.52",
+            "web3-eth-contract": "1.0.0-beta.52",
+            "web3-eth-ens": "1.0.0-beta.52",
+            "web3-eth-iban": "1.0.0-beta.52",
+            "web3-eth-personal": "1.0.0-beta.52",
+            "web3-net": "1.0.0-beta.52",
+            "web3-providers": "1.0.0-beta.52",
+            "web3-utils": "1.0.0-beta.52"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.52.tgz",
+          "integrity": "sha512-c03sH6y7ncp9tBPt0EZEcyFyou4kyYdr72VJMY8ip0JAfZgl4WI9XcGpD207z0lR4Ki1PSCfkh+ZigoXxggouw==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "ethers": "^4.0.27",
+            "lodash": "^4.17.11",
+            "web3-utils": "1.0.0-beta.52"
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.52.tgz",
+          "integrity": "sha512-B52yDVK2/3NKce1CESTZ/sD+6lU9pdNk4tPAtTkWTTPlejAbNlI04SdCX+hn2XJpDjsvU2HRSY3uNugVTrRQ6w==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.8",
+            "lodash": "^4.17.11",
+            "scrypt.js": "0.2.0",
+            "uuid": "3.3.2",
+            "web3-core": "1.0.0-beta.52",
+            "web3-core-helpers": "1.0.0-beta.52",
+            "web3-core-method": "1.0.0-beta.52",
+            "web3-providers": "1.0.0-beta.52",
+            "web3-utils": "1.0.0-beta.52"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.4.1",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+              "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            },
+            "eth-lib": {
+              "version": "0.2.8",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+              "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.52.tgz",
+          "integrity": "sha512-X5Eqi/onxaBw04urowcYXl4L7eS3NuAFdBxSYP14rdTtP03TbgZEJ1GZDftF3cgMorvfGKcTyxyK0VYj/l+lfg==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/bn.js": "^4.11.4",
+            "lodash": "^4.17.11",
+            "web3-core": "1.0.0-beta.52",
+            "web3-core-helpers": "1.0.0-beta.52",
+            "web3-core-method": "1.0.0-beta.52",
+            "web3-core-subscriptions": "1.0.0-beta.52",
+            "web3-eth-abi": "1.0.0-beta.52",
+            "web3-eth-accounts": "1.0.0-beta.52",
+            "web3-providers": "1.0.0-beta.52",
+            "web3-utils": "1.0.0-beta.52"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.0.0-beta.52.tgz",
+          "integrity": "sha512-8VTOF+v5pAjq1FmakXRceY6VrIoPB7DqfSc+K4aAOJ/tuIMIpe6pt0Bl9IYAbpgFrFqL7ow22d9xcd77ULIwiQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "eth-ens-namehash": "2.0.8",
+            "lodash": "^4.17.11",
+            "web3-core": "1.0.0-beta.52",
+            "web3-core-helpers": "1.0.0-beta.52",
+            "web3-core-method": "1.0.0-beta.52",
+            "web3-eth-abi": "1.0.0-beta.52",
+            "web3-eth-contract": "1.0.0-beta.52",
+            "web3-net": "1.0.0-beta.52",
+            "web3-providers": "1.0.0-beta.52",
+            "web3-utils": "1.0.0-beta.52"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.52.tgz",
+          "integrity": "sha512-LJZRZ+hZZPU9Fb7xR54mX1li5aKMp9xj9wgZZa4ikdL7iWi0rg1tOacEhbxWGQsjEYhGZYcvxhW9RIdHOwAySg==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "bn.js": "4.11.8",
+            "web3-utils": "1.0.0-beta.52"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.52.tgz",
+          "integrity": "sha512-tNjoB9KztpZL2ayjWYxaInwMrEGxBV7rGMt3hkhk9y4UxlK+8rZtrboz5hggzcgzHaVGnG73rdynhbuPU/cSAQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "web3-core": "1.0.0-beta.52",
+            "web3-core-helpers": "1.0.0-beta.52",
+            "web3-core-method": "1.0.0-beta.52",
+            "web3-net": "1.0.0-beta.52",
+            "web3-providers": "1.0.0-beta.52",
+            "web3-utils": "1.0.0-beta.52"
+          }
+        },
+        "web3-net": {
+          "version": "1.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.52.tgz",
+          "integrity": "sha512-rw66c5A5VTF/m3Acnr9ebIAgbr28q5jhXs8A8/F4VjbsDmUhQuQr3deyTPfyOEyupcnn6QRLoQ1EFVzeaUP7Ng==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "lodash": "^4.17.11",
+            "web3-core": "1.0.0-beta.52",
+            "web3-core-helpers": "1.0.0-beta.52",
+            "web3-core-method": "1.0.0-beta.52",
+            "web3-providers": "1.0.0-beta.52",
+            "web3-utils": "1.0.0-beta.52"
+          }
+        },
+        "web3-shh": {
+          "version": "1.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.52.tgz",
+          "integrity": "sha512-Qu9cb9fifUFIDTGujnBnInO3D2OCXDAmCowqMWebEazoZxk9P4oYWmumym1ZErixqEWREb4lkoayyEDSpARzSg==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "web3-core": "1.0.0-beta.52",
+            "web3-core-helpers": "1.0.0-beta.52",
+            "web3-core-method": "1.0.0-beta.52",
+            "web3-core-subscriptions": "1.0.0-beta.52",
+            "web3-net": "1.0.0-beta.52",
+            "web3-providers": "1.0.0-beta.52",
+            "web3-utils": "1.0.0-beta.52"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+        }
+      }
+    },
     "err-code": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
@@ -10952,6 +11324,14 @@
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^2.1.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "requires": {
+        "minipass": "^2.2.1"
       }
     },
     "fs-promise": {
@@ -16037,6 +16417,30 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "requires": {
+        "minipass": "^2.2.1"
+      }
     },
     "mississippi": {
       "version": "3.0.0",
@@ -26829,7 +27233,6 @@
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.1.tgz",
       "integrity": "sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -30724,6 +31127,65 @@
           "dev": true,
           "requires": {
             "async-limiter": "~1.0.0"
+          }
+        }
+      }
+    },
+    "web3-providers": {
+      "version": "1.0.0-beta.52",
+      "resolved": "https://registry.npmjs.org/web3-providers/-/web3-providers-1.0.0-beta.52.tgz",
+      "integrity": "sha512-eRmWOn6BeYfAt8UQmCRnqXo1++IjSiIz7+EY9WJ+m7J5ncq/gQN3idWQxT3QZzGRiAvZlO8ZUuF7ff0vuufakg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "@types/node": "^10.12.18",
+        "eventemitter3": "3.1.0",
+        "lodash": "^4.17.11",
+        "url-parse": "1.4.4",
+        "websocket": "^1.0.28",
+        "xhr2-cookies": "1.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "eventemitter3": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+          "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "nan": {
+          "version": "2.13.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
+        },
+        "url-parse": {
+          "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+          "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
+          "requires": {
+            "querystringify": "^2.0.0",
+            "requires-port": "^1.0.0"
+          }
+        },
+        "websocket": {
+          "version": "1.0.28",
+          "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.28.tgz",
+          "integrity": "sha512-00y/20/80P7H4bCYkzuuvvfDvh+dgtXi5kzDf3UcZwN6boTYaKvsrtZ5lIYm1Gsg48siMErd9M4zjSYfYFHTrA==",
+          "requires": {
+            "debug": "^2.2.0",
+            "nan": "^2.11.0",
+            "typedarray-to-buffer": "^3.1.5",
+            "yaeti": "^0.0.6"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dapparatus": "leapdao/dapparatus#0f22514",
     "dotenv": "^6.2.0",
     "eccrypto": "^1.1.0",
+    "erc721-balance": "0.0.1",
     "eth-crypto": "^1.3.2",
     "eth-ens-namehash": "^2.0.8",
     "ethereum-mnemonic-privatekey-utils": "^1.0.5",

--- a/src/App.js
+++ b/src/App.js
@@ -44,6 +44,7 @@ import customRPCHint from './customRPCHint.png';
 import namehash from 'eth-ens-namehash'
 import { Card, Box, ThemeProvider } from 'rimble-ui';
 import theme from "./theme"
+import { getTokensOfOwner } from "erc721-balance";
 
 //https://github.com/lesnitsky/react-native-webview-messaging/blob/v1/examples/react-native/web/index.js
 import RNMessageChannel from 'react-native-webview-messaging';
@@ -460,8 +461,7 @@ export default class App extends Component {
         }
       }
     }
-    setTimeout(this.poll.bind(this),150)
-    setTimeout(this.poll.bind(this),650)
+    this.poll.bind(this)();
     interval = setInterval(this.poll.bind(this),1500)
     intervalLong = setInterval(this.longPoll.bind(this),45000)
     setTimeout(this.longPoll.bind(this),150)
@@ -484,45 +484,36 @@ export default class App extends Component {
     window.removeEventListener("resize", this.updateDimensions.bind(this));
   }
   async poll() {
-    let badgeBalance = 0
-    if(this.state.contracts && this.state.contracts.ERC721Full){
-      //check for NFTs for this user
-      badgeBalance = await this.state.contracts.ERC721Full.balanceOf(this.state.account).call()
-      if(badgeBalance>0){
-        let update = false
-        for(let b = 0;b<badgeBalance;b++){
-          let thisBadgeId = await this.state.contracts.ERC721Full.tokenOfOwnerByIndex(this.state.account,b).call()
-          if(!this.state.badges[thisBadgeId]){
+    const { web3, contracts, account } = this.state;
+    let { badgeBalance } = this.state;
 
-            let thisBadgeData = await this.state.contracts.ERC721Full.tokenURI(thisBadgeId).call()
-            //console.log("BADGE",b,thisBadgeId,thisBadgeData)
-            if(!this.state.badges[thisBadgeId]){
-              console.log("Getting badge data ",thisBadgeData)
-              let data
-              try {
-                data = (await axios.get(thisBadgeData)).data
-              } catch(err) {
-                this.changeAlert({
-                  type: 'warning',
-                  message: "Couldn't load ERC721 data.",
-                });
-                console.log(err) 
-              }
-              if (data) {
-                  this.state.badges[thisBadgeId] = data
-                  this.state.badges[thisBadgeId].id = thisBadgeId
-                  update=true
-              }
-            }
-          }
-        }
-        if(update){
-          //console.log("Saving badges state...")
-          this.setState({badges:this.state.badges})
-        }
-
+    if (contracts && contracts.ERC721Full) {
+      let tokens;
+      try {
+        tokens = await getTokensOfOwner(
+          web3,
+          contracts.ERC721Full._address,
+          account
+        )
+      } catch(err) {
+        this.changeAlert({
+          type: 'warning',
+          message: "Couldn't load ERC721 data.",
+        });
+        console.log(err)
       }
+      if (badgeBalance !== tokens.length) {
+        badgeBalance = tokens.length;
 
+        const badges = tokens.reduce((initVal, currVal) => {
+          const { raw, tokenId } = currVal;
+          initVal[tokenId] = raw;
+          initVal[tokenId].id = tokenId;
+          return initVal;
+        }, {});
+
+        this.setState({badges});
+      }
     }
 
 


### PR DESCRIPTION
This PR uses erc721-balance to query tokens. It's a library by a friend of mine that automatically batches ERC721 balance calls to speed up the process of querying. 

As we'll switch out token querying with querying NST's on plasma, this is not very usefully likely.
I'll propose this change upstream as well.