### PR TITLE
Make message optional in Request

### DIFF
--- a/src/components/SendByScan.js
+++ b/src/components/SendByScan.js
@@ -103,11 +103,15 @@ class SendByScan extends Component {
           console.log("RETURN STATE:",this.props.returnState)
           let returnState = this.props.parseAndCleanPath(dataAfterColon)
           this.props.returnToState(returnState)
-        } else if(Web3.utils.isAddress(dataSplit[0]) && !isNaN(parseInt(dataSplit[1], 10)) && dataSplit[2]) {
+        // NOTE: We only need the address and the amount as absolutely necessary
+        // parts of the QR code scan. `message` is optional.
+        } else if(Web3.utils.isAddress(dataSplit[0]) && !isNaN(parseInt(dataSplit[1], 10))) {
           const returnState = {
             toAddress: dataSplit[0],
-            amount: parseInt(dataSplit[1], 10),
-            message: dataSplit[2]
+            amount: parseInt(dataSplit[1], 10)
+          }
+          if (dataSplit.length > 1) {
+            returnState.message = dataSplit[2]
           }
           this.props.returnToState(returnState);
         } else {


### PR DESCRIPTION
Fixes #123.

The following problem was solved: Say a user opened "Request" and typed in an amount but no "message", if then another user would scan that QR code, the page would reload.

This PR fixes this by making the message optional for the Request page.